### PR TITLE
refactor: Use stateless link instead of a statefull link

### DIFF
--- a/example/client/index.js
+++ b/example/client/index.js
@@ -1,14 +1,25 @@
 const gql = require('graphql-tag');
 const client = require('./client');
 
-client.query({
-  query: gql`
-    {
-      me {
-        firstName
-        lastName
-        fullName @computed(value: "$firstName && $lastName")
+client
+  .query({
+    query: gql`
+      query {
+        me {
+          firstName
+          lastName
+          fullName @computed(value: "$me.firstName && $me.lastName")
+          department {
+            access
+              @computed(
+                value: "Access to $me.department.name: $me.department.code"
+              )
+            name
+            code
+          }
+        }
       }
-    }
-  `,
-});
+    `,
+  })
+  .then(console.log)
+  .catch(console.log);

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const { removeDirectivesFromDocument } = require('apollo-utilities');
 const { mapObject, genConfigFromDoc, setComputedProperty } = require('./utils');
 
-const computedLint = new ApolloLink((operation, forwart) => {
+const computedLink = new ApolloLink((operation, forward) => {
   const operationDefinition = _.get(operation, 'query.definitions').find(
     definition => definition.kind === 'OperationDefinition'
   );
@@ -17,7 +17,7 @@ const computedLint = new ApolloLink((operation, forwart) => {
     operation.query
   );
 
-  return forwart(operation).map(response => {
+  return forward(operation).map(response => {
     mapObject(config, (val, key, obj) => {
       setComputedProperty(val, key, obj, response);
     });
@@ -28,4 +28,4 @@ const computedLint = new ApolloLink((operation, forwart) => {
   });
 });
 
-module.exports = computedLint;
+module.exports = computedLink;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "apollo-cache-inmemory": "^1.1.12",
     "apollo-client": "^2.2.8",
     "apollo-link-http": "^1.5.4",
-    "apollo-server-express": "^1.3.5",
+    "apollo-server-express": "^1.3.6",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "body-parser": "^1.18.2",
@@ -34,6 +34,6 @@
     "nodemon": "^1.17.3"
   },
   "dependencies": {
-    "lodash": "^4.17.5"
+    "lodash": "^4.17.10"
   }
 }

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,40 @@
+const _ = require('lodash');
+
+const mapObject = (obj, fn) =>
+  _.mapValues(
+    obj,
+    (v, k) => (_.isObject(v) ? mapObject(v, fn) : fn(v, k, obj))
+  );
+
+const genConfigFromDoc = tree =>
+  tree.reduce((acc, field) => {
+    if (field.kind === 'Field' && field.selectionSet) {
+      acc[field.name.value] = genConfigFromDoc(field.selectionSet.selections);
+    }
+
+    if (field.directives && field.directives.length > 0) {
+      const directive = field.directives
+        .find(d => d.name.value === 'computed')
+        .arguments.find(arg => arg.name.value === 'value');
+
+      acc[field.name.value] = directive.value.value;
+    }
+
+    return acc;
+  }, {});
+
+const setComputedProperty = (val, key, obj, data) => {
+  _.set(
+    obj,
+    key,
+    val.replace(/\$(\w+\.)+\w+/g, match =>
+      _.get(data, `data.${match.substring(1)}`)
+    )
+  );
+};
+
+module.exports = {
+  mapObject,
+  genConfigFromDoc,
+  setComputedProperty,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -267,19 +267,19 @@ apollo-link@^1.0.0, apollo-link@^1.2.1, apollo-link@^1.2.2:
     apollo-utilities "^1.0.0"
     zen-observable-ts "^0.8.9"
 
-apollo-server-core@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-1.3.5.tgz#36da3a6ee52b92fc4bb5710d44ced6b8fafebe2d"
+apollo-server-core@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-1.3.6.tgz#08636243c2de56fa8c267d68dd602cb1fbd323e3"
   dependencies:
     apollo-cache-control "^0.1.0"
     apollo-tracing "^0.1.0"
     graphql-extensions "^0.0.x"
 
-apollo-server-express@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-1.3.5.tgz#7cd010f7921356cd9b832032828aa0add36cb7ed"
+apollo-server-express@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-1.3.6.tgz#2120b05021a87def44fafd846e8a0e2a32852db7"
   dependencies:
-    apollo-server-core "^1.3.5"
+    apollo-server-core "^1.3.6"
     apollo-server-module-graphiql "^1.3.4"
 
 apollo-server-module-graphiql@^1.3.4:
@@ -3393,6 +3393,10 @@ lodash.sortby@^4.7.0:
 lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+lodash@^4.17.10:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 longest@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
I don't need to use stateful Apollo link